### PR TITLE
docs: replace deprecated happy --auth with auto-prompt

### DIFF
--- a/content/quick-start.mdx
+++ b/content/quick-start.mdx
@@ -30,8 +30,10 @@ Happy requires Node.js 18 or later (released  April 19, 2022) because we use the
 ### Scan the QR code with your mobile app
 
 ```bash
-happy --auth # Shows QR code
+happy # Auto-prompts for authentication on first run
 ```
+
+Or explicitly: `happy auth login`
 
 <Image className="my-4 rounded-lg border dark:border-gray-800 border-gray-200 shadow-lg dark:shadow-[0_0_40px_rgba(255,255,255,0.1)] dark:ring-1 dark:ring-white/20" src="/img/docs/cli-auth-example.png" alt="Screenshot of terminal showing the QR code plus secret code for manual entry" width={377} height={286} />
 


### PR DESCRIPTION
## Summary

The quick start guide references `happy --auth` which no longer exists. Running `happy` now auto-prompts for authentication on first run.

**Before:**
```bash
happy --auth # Shows QR code
```

**After:**
```bash
happy # Auto-prompts for authentication on first run
```

Also mentions `happy auth login` as an explicit alternative.

Closes slopus/happy#113

🤖 Generated with [Claude Code](https://claude.ai/code) via [Happy](https://happy.engineering)